### PR TITLE
Fix for required properties validation for inline objects (ObjectProperty), small bugfix, test improvement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,11 @@
       <version>4.1</version>
     </dependency>
     <dependency>
+      <groupId>net.bytebuddy</groupId>
+      <artifactId>byte-buddy</artifactId>
+      <version>1.7.8</version>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.8.2</version>

--- a/src/main/java/com/github/sylvainlaurent/maven/swaggervalidator/ValidateMojo.java
+++ b/src/main/java/com/github/sylvainlaurent/maven/swaggervalidator/ValidateMojo.java
@@ -10,6 +10,8 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.util.DirectoryScanner;
 
+import com.github.sylvainlaurent.maven.swaggervalidator.instrumentation.Instrumentation;
+
 @Mojo(name = "validate", defaultPhase = LifecyclePhase.PROCESS_SOURCES, threadSafe = true)
 public class ValidateMojo extends AbstractMojo {
 
@@ -32,6 +34,9 @@ public class ValidateMojo extends AbstractMojo {
 
     @Override
     public void execute() throws MojoExecutionException {
+
+        Instrumentation.init();
+
         final File[] files = getFiles();
         boolean encounteredError = false;
 

--- a/src/main/java/com/github/sylvainlaurent/maven/swaggervalidator/doc/traversal/node/ModelImplWrapper.java
+++ b/src/main/java/com/github/sylvainlaurent/maven/swaggervalidator/doc/traversal/node/ModelImplWrapper.java
@@ -1,6 +1,7 @@
 package com.github.sylvainlaurent.maven.swaggervalidator.doc.traversal.node;
 
 import static java.util.Collections.emptyList;
+import static org.apache.commons.collections4.ListUtils.emptyIfNull;
 import static org.apache.commons.lang3.reflect.FieldUtils.readField;
 
 import java.util.List;
@@ -24,7 +25,7 @@ public class ModelImplWrapper implements VisitableModel {
     @SuppressWarnings("unchecked")
     public List<String> getRequired() {
         try {
-            return (List<String>) readField(model, "required", true);
+            return emptyIfNull((List<String>) readField(model, "required", true));
         } catch (IllegalAccessException ex) {
             return emptyList();
         }

--- a/src/main/java/com/github/sylvainlaurent/maven/swaggervalidator/doc/traversal/node/ObjectPropertyRequiredStore.java
+++ b/src/main/java/com/github/sylvainlaurent/maven/swaggervalidator/doc/traversal/node/ObjectPropertyRequiredStore.java
@@ -1,0 +1,25 @@
+package com.github.sylvainlaurent.maven.swaggervalidator.doc.traversal.node;
+
+import static java.util.Collections.synchronizedMap;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ObjectPropertyRequiredStore {
+
+    private static final Map<String, List<String>> requiredObjectPropertiesMap = synchronizedMap(new HashMap<String, List<String>>());
+
+    public static List<String> get(Object objectProperties) {
+        return requiredObjectPropertiesMap.get(key(objectProperties));
+    }
+
+    public static void storeRequiredProperties(Object objectProperties, List<String> required) {
+        requiredObjectPropertiesMap.put(key(objectProperties), required);
+    }
+
+    private static String key(Object objectProperties) {
+        return String.valueOf(System.identityHashCode(objectProperties));
+    }
+
+}

--- a/src/main/java/com/github/sylvainlaurent/maven/swaggervalidator/doc/traversal/node/ObjectPropertyRequiredStore.java
+++ b/src/main/java/com/github/sylvainlaurent/maven/swaggervalidator/doc/traversal/node/ObjectPropertyRequiredStore.java
@@ -2,24 +2,19 @@ package com.github.sylvainlaurent.maven.swaggervalidator.doc.traversal.node;
 
 import static java.util.Collections.synchronizedMap;
 
-import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 
 public class ObjectPropertyRequiredStore {
 
-    private static final Map<String, List<String>> requiredObjectPropertiesMap = synchronizedMap(new HashMap<String, List<String>>());
+    private static final Map<Object, List<String>> requiredObjectPropertiesMap = synchronizedMap(new IdentityHashMap<Object, List<String>>());
 
-    public static List<String> get(Object objectProperties) {
-        return requiredObjectPropertiesMap.get(key(objectProperties));
+    public static List<String> get(Object objectProperty) {
+        return requiredObjectPropertiesMap.get(objectProperty);
     }
 
-    public static void storeRequiredProperties(Object objectProperties, List<String> required) {
-        requiredObjectPropertiesMap.put(key(objectProperties), required);
+    public static void storeRequiredProperties(Object objectProperty, List<String> required) {
+        requiredObjectPropertiesMap.put(objectProperty, required);
     }
-
-    private static String key(Object objectProperties) {
-        return String.valueOf(System.identityHashCode(objectProperties));
-    }
-
 }

--- a/src/main/java/com/github/sylvainlaurent/maven/swaggervalidator/doc/traversal/node/ObjectPropertyWrapper.java
+++ b/src/main/java/com/github/sylvainlaurent/maven/swaggervalidator/doc/traversal/node/ObjectPropertyWrapper.java
@@ -1,5 +1,9 @@
 package com.github.sylvainlaurent.maven.swaggervalidator.doc.traversal.node;
 
+import static java.util.Collections.synchronizedMap;
+import static org.apache.commons.collections4.ListUtils.emptyIfNull;
+
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -9,6 +13,8 @@ import io.swagger.models.properties.ObjectProperty;
 import io.swagger.models.properties.Property;
 
 public class ObjectPropertyWrapper implements VisitableProperty {
+
+    private static final Map<String, List<String>> requiredObjectPropertiesMap = synchronizedMap(new HashMap<String, List<String>>());
 
     private final ObjectProperty objectProperty;
     private final String propertyName;
@@ -29,10 +35,19 @@ public class ObjectPropertyWrapper implements VisitableProperty {
     }
 
     public List<String> getRequiredProperties() {
-        return objectProperty.getRequiredProperties();
+        return emptyIfNull(requiredObjectPropertiesMap.get(key(objectProperty)));
     }
 
     public Map<String, Property> getProperties() {
         return objectProperty.getProperties();
     }
+
+    public static void storeRequiredProperties(Object objectProperties, List<String> required) {
+        requiredObjectPropertiesMap.put(key(objectProperties), required);
+    }
+
+    private static String key(Object objectProperties) {
+        return String.valueOf(System.identityHashCode(objectProperties));
+    }
+
 }

--- a/src/main/java/com/github/sylvainlaurent/maven/swaggervalidator/doc/traversal/node/ObjectPropertyWrapper.java
+++ b/src/main/java/com/github/sylvainlaurent/maven/swaggervalidator/doc/traversal/node/ObjectPropertyWrapper.java
@@ -1,9 +1,7 @@
 package com.github.sylvainlaurent.maven.swaggervalidator.doc.traversal.node;
 
-import static java.util.Collections.synchronizedMap;
 import static org.apache.commons.collections4.ListUtils.emptyIfNull;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -14,7 +12,6 @@ import io.swagger.models.properties.Property;
 
 public class ObjectPropertyWrapper implements VisitableProperty {
 
-    private static final Map<String, List<String>> requiredObjectPropertiesMap = synchronizedMap(new HashMap<String, List<String>>());
 
     private final ObjectProperty objectProperty;
     private final String propertyName;
@@ -35,19 +32,14 @@ public class ObjectPropertyWrapper implements VisitableProperty {
     }
 
     public List<String> getRequiredProperties() {
-        return emptyIfNull(requiredObjectPropertiesMap.get(key(objectProperty)));
+        return emptyIfNull(ObjectPropertyRequiredStore.get(objectProperty));
     }
 
     public Map<String, Property> getProperties() {
         return objectProperty.getProperties();
     }
 
-    public static void storeRequiredProperties(Object objectProperties, List<String> required) {
-        requiredObjectPropertiesMap.put(key(objectProperties), required);
-    }
 
-    private static String key(Object objectProperties) {
-        return String.valueOf(System.identityHashCode(objectProperties));
-    }
+
 
 }

--- a/src/main/java/com/github/sylvainlaurent/maven/swaggervalidator/doc/traversal/node/ObjectPropertyWrapper.java
+++ b/src/main/java/com/github/sylvainlaurent/maven/swaggervalidator/doc/traversal/node/ObjectPropertyWrapper.java
@@ -39,7 +39,4 @@ public class ObjectPropertyWrapper implements VisitableProperty {
         return objectProperty.getProperties();
     }
 
-
-
-
 }

--- a/src/main/java/com/github/sylvainlaurent/maven/swaggervalidator/instrumentation/Instrumentation.java
+++ b/src/main/java/com/github/sylvainlaurent/maven/swaggervalidator/instrumentation/Instrumentation.java
@@ -1,0 +1,40 @@
+package com.github.sylvainlaurent.maven.swaggervalidator.instrumentation;
+
+import static net.bytebuddy.matcher.ElementMatchers.named;
+
+import net.bytebuddy.ByteBuddy;
+import net.bytebuddy.dynamic.ClassFileLocator;
+import net.bytebuddy.implementation.MethodDelegation;
+import net.bytebuddy.pool.TypePool;
+
+public final class Instrumentation {
+
+    private static final String CLASS_TO_BE_INSTRUMENTED = "io.swagger.models.properties.ObjectProperty";
+    private static final String METHOD_TO_BE_INSTRUMENTED = "setRequiredProperties";
+    private static boolean initialized = false;
+
+    private Instrumentation() {
+        // EMPTY
+    }
+
+    public static synchronized void init() {
+
+        if (initialized) {
+            return;
+        }
+
+        try {
+            ClassLoader classLoader = Instrumentation.class.getClassLoader();
+            TypePool typePool = TypePool.Default.of(classLoader);
+
+            new ByteBuddy().rebase(typePool.describe(CLASS_TO_BE_INSTRUMENTED).resolve(), ClassFileLocator.ForClassLoader.of(classLoader))
+                           .method(named(METHOD_TO_BE_INSTRUMENTED))
+                           .intercept(MethodDelegation.to(ObjectPropertyRequiredInterceptor.class))
+                           .make()
+                           .load(classLoader);
+            initialized = true;
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+}

--- a/src/main/java/com/github/sylvainlaurent/maven/swaggervalidator/instrumentation/ObjectPropertyRequiredInterceptor.java
+++ b/src/main/java/com/github/sylvainlaurent/maven/swaggervalidator/instrumentation/ObjectPropertyRequiredInterceptor.java
@@ -1,0 +1,25 @@
+package com.github.sylvainlaurent.maven.swaggervalidator.instrumentation;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+
+import com.github.sylvainlaurent.maven.swaggervalidator.doc.traversal.node.ObjectPropertyWrapper;
+
+import net.bytebuddy.implementation.bind.annotation.Argument;
+import net.bytebuddy.implementation.bind.annotation.RuntimeType;
+import net.bytebuddy.implementation.bind.annotation.SuperCall;
+import net.bytebuddy.implementation.bind.annotation.This;
+
+public final class ObjectPropertyRequiredInterceptor {
+
+    private ObjectPropertyRequiredInterceptor() {
+        // EMPTY
+    }
+
+    @RuntimeType
+    public static Object setRequiredProperties(@This Object object, @SuperCall Callable<?> zuper, @Argument(value = 0) List<String> requiredProperties) throws Exception {
+        ObjectPropertyWrapper.storeRequiredProperties(object, requiredProperties);
+        return zuper.call();
+    }
+
+}

--- a/src/main/java/com/github/sylvainlaurent/maven/swaggervalidator/instrumentation/ObjectPropertyRequiredInterceptor.java
+++ b/src/main/java/com/github/sylvainlaurent/maven/swaggervalidator/instrumentation/ObjectPropertyRequiredInterceptor.java
@@ -3,7 +3,7 @@ package com.github.sylvainlaurent.maven.swaggervalidator.instrumentation;
 import java.util.List;
 import java.util.concurrent.Callable;
 
-import com.github.sylvainlaurent.maven.swaggervalidator.doc.traversal.node.ObjectPropertyWrapper;
+import com.github.sylvainlaurent.maven.swaggervalidator.doc.traversal.node.ObjectPropertyRequiredStore;
 
 import net.bytebuddy.implementation.bind.annotation.Argument;
 import net.bytebuddy.implementation.bind.annotation.RuntimeType;
@@ -18,7 +18,7 @@ public final class ObjectPropertyRequiredInterceptor {
 
     @RuntimeType
     public static Object setRequiredProperties(@This Object object, @SuperCall Callable<?> zuper, @Argument(value = 0) List<String> requiredProperties) throws Exception {
-        ObjectPropertyWrapper.storeRequiredProperties(object, requiredProperties);
+        ObjectPropertyRequiredStore.storeRequiredProperties(object, requiredProperties);
         return zuper.call();
     }
 

--- a/src/main/java/com/github/sylvainlaurent/maven/swaggervalidator/semantic/RequiredPropertiesValidator.java
+++ b/src/main/java/com/github/sylvainlaurent/maven/swaggervalidator/semantic/RequiredPropertiesValidator.java
@@ -124,7 +124,6 @@ public class RequiredPropertiesValidator extends AbstractVisitor {
 
     @Override
     protected void handle(ObjectPropertyWrapper objectProperty) {
-        //TODO: this is not working because required properties returned are not the original one,
         validate(objectProperty.getProperties().keySet(), objectProperty.getRequiredProperties());
         for (Map.Entry<String, Property> property : objectProperty.getProperties().entrySet()) {
             createVisitableProperty(property.getKey(), property.getValue()).accept(this);

--- a/src/main/java/com/github/sylvainlaurent/maven/swaggervalidator/semantic/SemanticValidator.java
+++ b/src/main/java/com/github/sylvainlaurent/maven/swaggervalidator/semantic/SemanticValidator.java
@@ -1,6 +1,7 @@
 package com.github.sylvainlaurent.maven.swaggervalidator.semantic;
 
 import static com.github.sylvainlaurent.maven.swaggervalidator.doc.traversal.VisitableModelFactory.createVisitableModel;
+import static org.apache.commons.collections4.MapUtils.emptyIfNull;
 
 import java.util.Collections;
 import java.util.Map;
@@ -23,7 +24,7 @@ public class SemanticValidator {
     private final SemanticErrorsCollector errorCollector = new SemanticErrorsCollector();
 
     public SemanticValidator(Swagger swagger) {
-        definitions = swagger.getDefinitions() != null ? swagger.getDefinitions() : Collections.<String, Model>emptyMap();
+        definitions = emptyIfNull(swagger.getDefinitions());
         referenceValidator = new ReferenceValidator(definitions, errorCollector);
         requiredPropertiesValidator = new RequiredPropertiesValidator(errorCollector);
         inheritanceChainPropertiesValidator = new InheritanceChainPropertiesValidator(definitions, errorCollector);

--- a/src/test/java/com/github/sylvainlaurent/maven/swaggervalidator/ValidationServiceTest.java
+++ b/src/test/java/com/github/sylvainlaurent/maven/swaggervalidator/ValidationServiceTest.java
@@ -8,7 +8,9 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
+@RunWith(ValidatorJunitRunner.class)
 public class ValidationServiceTest {
     private final ValidationService service = new ValidationService();
 

--- a/src/test/java/com/github/sylvainlaurent/maven/swaggervalidator/ValidatorJunitRunner.java
+++ b/src/test/java/com/github/sylvainlaurent/maven/swaggervalidator/ValidatorJunitRunner.java
@@ -1,0 +1,20 @@
+package com.github.sylvainlaurent.maven.swaggervalidator;
+
+import org.junit.runner.notification.RunNotifier;
+import org.junit.runners.BlockJUnit4ClassRunner;
+import org.junit.runners.model.InitializationError;
+
+import com.github.sylvainlaurent.maven.swaggervalidator.instrumentation.Instrumentation;
+
+public class ValidatorJunitRunner extends BlockJUnit4ClassRunner {
+
+    public ValidatorJunitRunner(Class<?> klass) throws InitializationError {
+        super(klass);
+    }
+
+    @Override
+    public void run(RunNotifier notifier) {
+        Instrumentation.init();
+        super.run(notifier);
+    }
+}

--- a/src/test/java/com/github/sylvainlaurent/maven/swaggervalidator/semantic/SemanticValidatorTest.java
+++ b/src/test/java/com/github/sylvainlaurent/maven/swaggervalidator/semantic/SemanticValidatorTest.java
@@ -130,7 +130,9 @@ public class SemanticValidatorTest {
         assertTrue(result.hasErrors());
         List<SemanticError> semanticErrors = result.getErrors();
         assertEquals(1, semanticErrors.size());
-        assertEquals(REQUIRED_PROPERTIES_NOT_DEFINED_AS_OBJECT_PROPERTIES, semanticErrors.get(0).getErrorType());
+        DefinitionsSemanticError semanticError = (DefinitionsSemanticError)semanticErrors.get(0);
+        assertEquals(REQUIRED_PROPERTIES_NOT_DEFINED_AS_OBJECT_PROPERTIES, semanticError.getErrorType());
+        assertEquals("Product", semanticError.getPath());
     }
 
     @Test
@@ -143,7 +145,9 @@ public class SemanticValidatorTest {
         assertTrue(result.hasErrors());
         List<SemanticError> semanticErrors = result.getErrors();
         assertEquals(1, semanticErrors.size());
-        assertEquals(REQUIRED_PROPERTIES_NOT_DEFINED_AS_OBJECT_PROPERTIES, semanticErrors.get(0).getErrorType());
+        DefinitionsSemanticError semanticError = (DefinitionsSemanticError)semanticErrors.get(0);
+        assertEquals(REQUIRED_PROPERTIES_NOT_DEFINED_AS_OBJECT_PROPERTIES, semanticError.getErrorType());
+        assertEquals("Product.category.image", semanticError.getPath());
     }
 
     @Test
@@ -154,7 +158,9 @@ public class SemanticValidatorTest {
         assertTrue(result.hasErrors());
         List<SemanticError> semanticErrors = result.getErrors();
         assertEquals(1, semanticErrors.size());
-        assertEquals(REQUIRED_PROPERTIES_ARE_DUPLICATED, semanticErrors.get(0).getErrorType());
+        DefinitionsSemanticError semanticError = (DefinitionsSemanticError)semanticErrors.get(0);
+        assertEquals(REQUIRED_PROPERTIES_ARE_DUPLICATED, semanticError.getErrorType());
+        assertEquals("Product", semanticError.getPath());
     }
 
     @Test
@@ -167,7 +173,9 @@ public class SemanticValidatorTest {
         assertTrue(result.hasErrors());
         List<SemanticError> semanticErrors = result.getErrors();
         assertEquals(1, semanticErrors.size());
-        assertEquals(REQUIRED_PROPERTIES_ARE_DUPLICATED, semanticErrors.get(0).getErrorType());
+        DefinitionsSemanticError semanticError = (DefinitionsSemanticError)semanticErrors.get(0);
+        assertEquals(REQUIRED_PROPERTIES_ARE_DUPLICATED, semanticError.getErrorType());
+        assertEquals("Product.category", semanticError.getPath());
     }
 
     @Test
@@ -180,9 +188,12 @@ public class SemanticValidatorTest {
         List<SemanticError> semanticErrors = result.getErrors();
         assertEquals(2, semanticErrors.size());
 
-        assertEquals(DISCRIMINATOR_NOT_DEFINED_AS_PROPERTY, semanticErrors.get(0).getErrorType());
-        assertEquals(DISCRIMINATOR_NOT_DEFINED_AS_REQUIRED_PROPERTY, semanticErrors.get(1).getErrorType());
-
+        DefinitionsSemanticError error1 = (DefinitionsSemanticError)semanticErrors.get(0);
+        DefinitionsSemanticError error2 = (DefinitionsSemanticError)semanticErrors.get(1);
+        assertEquals(DISCRIMINATOR_NOT_DEFINED_AS_PROPERTY, error1.getErrorType());
+        assertEquals("Product", error1.getPath());
+        assertEquals(DISCRIMINATOR_NOT_DEFINED_AS_REQUIRED_PROPERTY, error2.getErrorType());
+        assertEquals("Product", error2.getPath());
     }
 
     @Test
@@ -194,7 +205,9 @@ public class SemanticValidatorTest {
         assertTrue(result.hasErrors());
         List<SemanticError> semanticErrors = result.getErrors();
         assertEquals(1, semanticErrors.size());
-        assertEquals(DISCRIMINATOR_NOT_DEFINED_AS_REQUIRED_PROPERTY, semanticErrors.get(0).getErrorType());
+        DefinitionsSemanticError error = (DefinitionsSemanticError)semanticErrors.get(0);
+        assertEquals(DISCRIMINATOR_NOT_DEFINED_AS_REQUIRED_PROPERTY, error.getErrorType());
+        assertEquals("Product", error.getPath());
     }
 
     @Test
@@ -221,7 +234,10 @@ public class SemanticValidatorTest {
         assertTrue(result.hasErrors());
         List<SemanticError> semanticErrors = result.getErrors();
         assertEquals(1, semanticErrors.size());
-        assertEquals(ITEMS_PROPERTY_IS_NOT_DEFINED_IN_ARRAY, semanticErrors.get(0).getErrorType());
+        DefinitionsSemanticError definitionsSemanticError = (DefinitionsSemanticError) semanticErrors.get(0);
+        assertEquals(ITEMS_PROPERTY_IS_NOT_DEFINED_IN_ARRAY, definitionsSemanticError.getErrorType());
+        assertEquals("Product.categories", definitionsSemanticError.getPath());
+
     }
 
     private SwaggerDeserializationResult readDoc(String location) {

--- a/src/test/java/com/github/sylvainlaurent/maven/swaggervalidator/semantic/SemanticValidatorTest.java
+++ b/src/test/java/com/github/sylvainlaurent/maven/swaggervalidator/semantic/SemanticValidatorTest.java
@@ -19,10 +19,10 @@ import static org.junit.Assert.assertTrue;
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
-import com.github.sylvainlaurent.maven.swaggervalidator.instrumentation.Instrumentation;
+import com.github.sylvainlaurent.maven.swaggervalidator.ValidatorJunitRunner;
 import com.github.sylvainlaurent.maven.swaggervalidator.semantic.error.DefinitionsSemanticError;
 import com.github.sylvainlaurent.maven.swaggervalidator.semantic.error.SemanticError;
 
@@ -30,12 +30,8 @@ import io.swagger.models.auth.AuthorizationValue;
 import io.swagger.parser.Swagger20Parser;
 import io.swagger.parser.util.SwaggerDeserializationResult;
 
+@RunWith(ValidatorJunitRunner.class)
 public class SemanticValidatorTest {
-
-    @Before
-    public void setup(){
-        Instrumentation.init();
-    }
 
     @Test
     public void operations_semantic_validation_should_fail_when_two_path_are_equal() {
@@ -117,7 +113,7 @@ public class SemanticValidatorTest {
         assertEquals(expectedErrorPaths.size(), semanticErrors.size());
 
         DefinitionsSemanticError semanticError1 = (DefinitionsSemanticError) semanticErrors.get(0);
-        DefinitionsSemanticError semanticError2 = (DefinitionsSemanticError) semanticErrors.get(0);
+        DefinitionsSemanticError semanticError2 = (DefinitionsSemanticError) semanticErrors.get(1);
 
         List<String> errorPaths = asList(semanticError1.getPath(), semanticError1.getPath());
         assertTrue(expectedErrorPaths.containsAll(errorPaths));
@@ -140,7 +136,8 @@ public class SemanticValidatorTest {
     @Test
     public void definitions_semantic_validation_should_fail_when_object_property_contains_required_properties_not_defined() {
 
-        final SwaggerDeserializationResult swaggerResult = readDoc("src/test/resources/semantic-validation/swagger-doc-required-properties-not-defined-for-object-property.yml");
+        final SwaggerDeserializationResult swaggerResult = readDoc(
+            "src/test/resources/semantic-validation/swagger-doc-required-properties-not-defined-for-object-property.yml");
         SemanticValidationResult result = new SemanticValidator(swaggerResult.getSwagger()).validate();
 
         assertTrue(result.hasErrors());
@@ -163,7 +160,8 @@ public class SemanticValidatorTest {
     @Test
     public void definitions_semantic_validation_should_fail_when_object_property_contains_duplicated_required_properties() {
 
-        final SwaggerDeserializationResult swaggerResult = readDoc("src/test/resources/semantic-validation/swagger-doc-required-properties-duplicated-for-object-property.yml");
+        final SwaggerDeserializationResult swaggerResult = readDoc(
+            "src/test/resources/semantic-validation/swagger-doc-required-properties-duplicated-for-object-property.yml");
         SemanticValidationResult result = new SemanticValidator(swaggerResult.getSwagger()).validate();
 
         assertTrue(result.hasErrors());

--- a/src/test/java/com/github/sylvainlaurent/maven/swaggervalidator/semantic/SemanticValidatorTest.java
+++ b/src/test/java/com/github/sylvainlaurent/maven/swaggervalidator/semantic/SemanticValidatorTest.java
@@ -19,8 +19,10 @@ import static org.junit.Assert.assertTrue;
 import java.util.Collections;
 import java.util.List;
 
+import org.junit.Before;
 import org.junit.Test;
 
+import com.github.sylvainlaurent.maven.swaggervalidator.instrumentation.Instrumentation;
 import com.github.sylvainlaurent.maven.swaggervalidator.semantic.error.DefinitionsSemanticError;
 import com.github.sylvainlaurent.maven.swaggervalidator.semantic.error.SemanticError;
 
@@ -29,6 +31,11 @@ import io.swagger.parser.Swagger20Parser;
 import io.swagger.parser.util.SwaggerDeserializationResult;
 
 public class SemanticValidatorTest {
+
+    @Before
+    public void setup(){
+        Instrumentation.init();
+    }
 
     @Test
     public void operations_semantic_validation_should_fail_when_two_path_are_equal() {
@@ -131,8 +138,32 @@ public class SemanticValidatorTest {
     }
 
     @Test
+    public void definitions_semantic_validation_should_fail_when_object_property_contains_required_properties_not_defined() {
+
+        final SwaggerDeserializationResult swaggerResult = readDoc("src/test/resources/semantic-validation/swagger-doc-required-properties-not-defined-for-object-property.yml");
+        SemanticValidationResult result = new SemanticValidator(swaggerResult.getSwagger()).validate();
+
+        assertTrue(result.hasErrors());
+        List<SemanticError> semanticErrors = result.getErrors();
+        assertEquals(1, semanticErrors.size());
+        assertEquals(REQUIRED_PROPERTIES_NOT_DEFINED_AS_OBJECT_PROPERTIES, semanticErrors.get(0).getErrorType());
+    }
+
+    @Test
     public void definitions_semantic_validation_should_fail_when_model_contains_duplicated_required_properties() {
         final SwaggerDeserializationResult swaggerResult = readDoc("src/test/resources/semantic-validation/swagger-doc-required-properties-duplicated.yml");
+        SemanticValidationResult result = new SemanticValidator(swaggerResult.getSwagger()).validate();
+
+        assertTrue(result.hasErrors());
+        List<SemanticError> semanticErrors = result.getErrors();
+        assertEquals(1, semanticErrors.size());
+        assertEquals(REQUIRED_PROPERTIES_ARE_DUPLICATED, semanticErrors.get(0).getErrorType());
+    }
+
+    @Test
+    public void definitions_semantic_validation_should_fail_when_object_property_contains_duplicated_required_properties() {
+
+        final SwaggerDeserializationResult swaggerResult = readDoc("src/test/resources/semantic-validation/swagger-doc-required-properties-duplicated-for-object-property.yml");
         SemanticValidationResult result = new SemanticValidator(swaggerResult.getSwagger()).validate();
 
         assertTrue(result.hasErrors());

--- a/src/test/resources/semantic-validation/swagger-doc-required-properties-duplicated-for-object-property.yml
+++ b/src/test/resources/semantic-validation/swagger-doc-required-properties-duplicated-for-object-property.yml
@@ -1,0 +1,54 @@
+swagger: '2.0'
+info:
+  title: Test API
+  description: Test API
+  version: "1.0.0"
+host: none
+schemes:
+  - https
+basePath: /v1
+produces:
+  - application/json
+paths:
+  /category/{id}/product/{productId}:
+    get:
+      parameters:
+      - name: id
+        in: path
+        required: true
+        type: string
+      - name: productId
+        in: path
+        required: true
+        type: string
+      operationId: get
+      summary: test service
+      responses:
+        200:
+          description: ok
+          schema:
+            type: string
+
+definitions:
+
+  Product:
+    type: object
+    properties:
+      id:
+        type: string
+      name:
+        type: string
+      category:
+        type: object
+        properties:
+          categoryId:
+            type: string
+          categoryName:
+            type: string
+        required:
+          - categoryId
+          - categoryName
+          - categoryName
+    required:
+      - id
+      - name

--- a/src/test/resources/semantic-validation/swagger-doc-required-properties-not-defined-for-object-property.yml
+++ b/src/test/resources/semantic-validation/swagger-doc-required-properties-not-defined-for-object-property.yml
@@ -1,0 +1,60 @@
+swagger: '2.0'
+info:
+  title: Test API
+  description: Test API
+  version: "1.0.0"
+host: none
+schemes:
+  - https
+basePath: /v1
+produces:
+  - application/json
+paths:
+  /category/{id}/product/{productId}:
+    get:
+      parameters:
+      - name: id
+        in: path
+        required: true
+        type: string
+      - name: productId
+        in: path
+        required: true
+        type: string
+      operationId: getProduct
+      summary: test service
+      responses:
+        200:
+          description: ok
+          schema:
+            type: string
+
+definitions:
+
+  Product:
+    type: object
+    properties:
+      id:
+        type: string
+      name:
+        type: string
+      category:
+        type: object
+        properties:
+          categoryName:
+            type: string
+          categoryId:
+            type: string
+          image:
+            type: object
+            properties:
+              url:
+                type: string
+            required:
+              - url
+              #undefined required properties
+              - format
+              - size
+    required:
+      - id
+      - name


### PR DESCRIPTION
This is more a workaround due to the fact that swagger-core doesn't retain original required properties (https://github.com/swagger-api/swagger-core/issues/2479) and they are not going to change this behavior.

